### PR TITLE
add(feed): submit Geotribu English blog

### DIFF
--- a/data/subscribers.json
+++ b/data/subscribers.json
@@ -178,5 +178,11 @@
     "name": "Mergin Maps",
     "shortname": "mergin_maps",
     "is_active": true
+  },
+  {
+    "feed": "https://blog.geotribu.net/feed_rss_created.xml",
+    "name": "Geotribu",
+    "shortname": "geotribu_en",
+    "is_active": true
   }
 ]


### PR DESCRIPTION
I would like to add the https://blog.geotribu.net/ to feeds. For now, the published content is mainly related to QGIS. Waiting for #29 to add categories.

Waiting for #28 to submit the  French website.

Disclaimer: I'm one of the main contributors to Geotribu.

